### PR TITLE
Fix missing `chipType` field while loading an instrument

### DIFF
--- a/src/lib/components/Instruments/InstrumentsView.svelte
+++ b/src/lib/components/Instruments/InstrumentsView.svelte
@@ -38,8 +38,9 @@
 		resolveInstrumentChipType
 	} from '../../services/instrument/instrument-filter';
 	import {
-		instrumentFromPreset,
-		parseInstrumentPreset
+		applyInstrumentPreset,
+		parseInstrumentPreset,
+		type InstrumentPresetPayload
 	} from '../../services/instrument/instrument-preset';
 	import { editorStateStore } from '../../stores/editor-state.svelte';
 	import { projectStore } from '../../stores/project.svelte';
@@ -459,6 +460,35 @@
 		});
 	}
 
+	function replaceInstrumentFromPreset(
+		id: string,
+		payload: InstrumentPresetPayload,
+		label: string
+	): void {
+		if (!chip) return;
+		const updated = applyInstrumentPreset(allInstruments, payload, id, chip.type);
+		if (updated) {
+			const beforeInstruments = projectStore.cloneForHistory(projectStore.instruments);
+			projectStore.instruments = updated;
+			projectStore.recordHistory(
+				{
+					type: 'instrument.replace',
+					label,
+					affectedDomains: ['instruments']
+				},
+				[
+					projectStore.createSetDiff(
+						['instruments'],
+						beforeInstruments,
+						projectStore.instruments
+					)
+				]
+			);
+		}
+		services.audioService.updateInstruments(projectStore.instruments);
+		requestPatternRedraw?.();
+	}
+
 	async function loadInstrument(): Promise<void> {
 		flushInstrumentUpdateHistory();
 		if (!chip || chipInstruments.length === 0) return;
@@ -469,30 +499,7 @@
 				throw new Error('Invalid format: expected an instrument object');
 			}
 			const currentId = chipInstruments[selectedInstrumentIndex]?.id ?? '01';
-			const replacement = instrumentFromPreset(payload, currentId, chip.type);
-			const idx = allInstruments.findIndex((inst) => inst.id === currentId);
-			if (idx >= 0) {
-				const beforeInstruments = projectStore.cloneForHistory(projectStore.instruments);
-				const updated = [...allInstruments];
-				updated[idx] = replacement;
-				projectStore.instruments = updated;
-				projectStore.recordHistory(
-					{
-						type: 'instrument.replace',
-						label: `Replace instrument ${currentId}`,
-						affectedDomains: ['instruments']
-					},
-					[
-						projectStore.createSetDiff(
-							['instruments'],
-							beforeInstruments,
-							projectStore.instruments
-						)
-					]
-				);
-			}
-			services.audioService.updateInstruments(projectStore.instruments);
-			requestPatternRedraw?.();
+			replaceInstrumentFromPreset(currentId, payload, `Replace instrument ${currentId}`);
 		} catch (err) {
 			if ((err as Error).message !== 'No file selected') {
 				alert('Failed to load instrument: ' + (err as Error).message);
@@ -510,30 +517,7 @@
 			return;
 		}
 		const currentId = chipInstruments[selectedInstrumentIndex]?.id ?? '01';
-		const replacement = instrumentFromPreset(payload, currentId, chip.type);
-		const idx = allInstruments.findIndex((inst) => inst.id === currentId);
-		if (idx >= 0) {
-			const beforeInstruments = projectStore.cloneForHistory(projectStore.instruments);
-			const updated = [...allInstruments];
-			updated[idx] = replacement;
-			projectStore.instruments = updated;
-			projectStore.recordHistory(
-				{
-					type: 'instrument.replace',
-					label: `Apply preset to instrument ${currentId}`,
-					affectedDomains: ['instruments']
-				},
-				[
-					projectStore.createSetDiff(
-						['instruments'],
-						beforeInstruments,
-						projectStore.instruments
-					)
-				]
-			);
-		}
-		services.audioService.updateInstruments(projectStore.instruments);
-		requestPatternRedraw?.();
+		replaceInstrumentFromPreset(currentId, payload, `Apply preset to instrument ${currentId}`);
 	}
 
 	function getInstrumentIdError(index: number, id: string): string | null {

--- a/src/lib/components/Instruments/InstrumentsView.svelte
+++ b/src/lib/components/Instruments/InstrumentsView.svelte
@@ -37,6 +37,10 @@
 		getOrderedProjectChipTypes,
 		resolveInstrumentChipType
 	} from '../../services/instrument/instrument-filter';
+	import {
+		instrumentFromPreset,
+		parseInstrumentPreset
+	} from '../../services/instrument/instrument-preset';
 	import { editorStateStore } from '../../stores/editor-state.svelte';
 	import { projectStore } from '../../stores/project.svelte';
 	import { computeGridRows } from '../../utils/compute-grid-rows';
@@ -460,37 +464,17 @@
 		if (!chip || chipInstruments.length === 0) return;
 		try {
 			const text = await pickFileAsText();
-			const parsed: unknown = JSON.parse(text);
-			const item = Array.isArray(parsed) ? parsed[0] : parsed;
-			if (
-				item == null ||
-				typeof item !== 'object' ||
-				!Array.isArray((item as Record<string, unknown>).rows)
-			) {
+			const payload = parseInstrumentPreset(JSON.parse(text));
+			if (!payload) {
 				throw new Error('Invalid format: expected an instrument object');
 			}
-			const o = item as Record<string, unknown>;
-			const rows = (o.rows as Record<string, unknown>[]).map((r) => new InstrumentRow(r));
-			const loop = typeof o.loop === 'number' ? o.loop : 0;
-			const name = o.name != null ? String(o.name) : '';
 			const currentId = chipInstruments[selectedInstrumentIndex]?.id ?? '01';
-			const replacement = new InstrumentModel(
-				currentId,
-				rows,
-				loop,
-				name || `Instrument ${currentId}`,
-				chip.type
-			);
+			const replacement = instrumentFromPreset(payload, currentId, chip.type);
 			const idx = allInstruments.findIndex((inst) => inst.id === currentId);
 			if (idx >= 0) {
 				const beforeInstruments = projectStore.cloneForHistory(projectStore.instruments);
 				const updated = [...allInstruments];
-				updated[idx] = new InstrumentModel(
-					currentId,
-					replacement.rows.map((r) => new InstrumentRow({ ...r })),
-					replacement.loop,
-					replacement.name
-				);
+				updated[idx] = replacement;
 				projectStore.instruments = updated;
 				projectStore.recordHistory(
 					{
@@ -519,36 +503,19 @@
 	async function openPresets(): Promise<void> {
 		flushInstrumentUpdateHistory();
 		if (!chip || chipInstruments.length === 0) return;
-		const item = await open(PresetsModal, { presetType: 'instrument' });
-		if (
-			item == null ||
-			typeof item !== 'object' ||
-			!Array.isArray((item as Record<string, unknown>).rows)
-		) {
+		const payload = parseInstrumentPreset(
+			await open(PresetsModal, { presetType: 'instrument' })
+		);
+		if (!payload) {
 			return;
 		}
-		const o = item as Record<string, unknown>;
-		const rows = (o.rows as Record<string, unknown>[]).map((r) => new InstrumentRow(r));
-		const loop = typeof o.loop === 'number' ? o.loop : 0;
-		const name = o.name != null ? String(o.name) : '';
 		const currentId = chipInstruments[selectedInstrumentIndex]?.id ?? '01';
-		const replacement = new InstrumentModel(
-			currentId,
-			rows,
-			loop,
-			name || `Instrument ${currentId}`,
-			chip.type
-		);
+		const replacement = instrumentFromPreset(payload, currentId, chip.type);
 		const idx = allInstruments.findIndex((inst) => inst.id === currentId);
 		if (idx >= 0) {
 			const beforeInstruments = projectStore.cloneForHistory(projectStore.instruments);
 			const updated = [...allInstruments];
-			updated[idx] = new InstrumentModel(
-				currentId,
-				replacement.rows.map((r) => new InstrumentRow({ ...r })),
-				replacement.loop,
-				replacement.name
-			);
+			updated[idx] = replacement;
 			projectStore.instruments = updated;
 			projectStore.recordHistory(
 				{

--- a/src/lib/components/Modal/PresetsModal.svelte
+++ b/src/lib/components/Modal/PresetsModal.svelte
@@ -6,6 +6,7 @@
 	import type { TreeNode } from '../TreeView/types';
 	import type { InstrumentPresetData } from '../../presets/instrument-presets';
 	import { getInstrumentPresetTree } from '../../presets/instrument-presets';
+	import { parseInstrumentPreset } from '../../services/instrument/instrument-preset';
 
 	let {
 		resolve,
@@ -36,16 +37,11 @@
 		error = null;
 		try {
 			const text = await node.data.load();
-			const parsed: unknown = JSON.parse(text);
-			const item = Array.isArray(parsed) ? parsed[0] : parsed;
-			if (
-				item == null ||
-				typeof item !== 'object' ||
-				!Array.isArray((item as Record<string, unknown>).rows)
-			) {
+			const payload = parseInstrumentPreset(JSON.parse(text));
+			if (!payload) {
 				throw new Error('Invalid format: expected an instrument object');
 			}
-			resolve?.(item);
+			resolve?.(payload);
 		} catch (err) {
 			error = (err as Error).message;
 		} finally {

--- a/src/lib/presets/instrument-presets.ts
+++ b/src/lib/presets/instrument-presets.ts
@@ -1,4 +1,5 @@
 import type { TreeNode } from '../components/TreeView/types';
+import { parseInstrumentPreset } from '../services/instrument/instrument-preset';
 
 const glob = import.meta.glob('../../presets/instruments/**/*.json', {
 	query: '?raw',
@@ -20,17 +21,13 @@ function pathToCategoryAndLabel(relativePath: string): { category: string; label
 }
 
 function getNameFromPresetContent(raw: string): string | null {
+	let parsed: unknown;
 	try {
-		const parsed: unknown = JSON.parse(raw);
-		const item = Array.isArray(parsed) ? parsed[0] : parsed;
-		if (item != null && typeof item === 'object' && 'name' in item) {
-			const name = (item as Record<string, unknown>).name;
-			return name != null ? String(name) : null;
-		}
+		parsed = JSON.parse(raw);
 	} catch {
-		// ignore
+		return null;
 	}
-	return null;
+	return parseInstrumentPreset(parsed)?.name || null;
 }
 
 export function getInstrumentPresetTree(): TreeNode<InstrumentPresetData>[] {

--- a/src/lib/services/instrument/instrument-preset.ts
+++ b/src/lib/services/instrument/instrument-preset.ts
@@ -7,9 +7,9 @@ export type InstrumentPresetPayload = {
 };
 
 /**
- * Reads an instrument preset payload, accepting either a bare instrument object or a
- * single-element array of one, which is the shape both the bundled presets and exported
- * instrument files come in. Returns null when the payload carries no row array.
+ * Reads an instrument preset payload out of parsed JSON, taking a bare instrument object or
+ * the first entry when the JSON holds an array of them. Returns null when the payload carries
+ * no row array.
  */
 export function parseInstrumentPreset(parsed: unknown): InstrumentPresetPayload | null {
 	const item = Array.isArray(parsed) ? parsed[0] : parsed;
@@ -26,9 +26,8 @@ export function parseInstrumentPreset(parsed: unknown): InstrumentPresetPayload 
 }
 
 /**
- * Builds the instrument a preset replaces a slot with, tagged for the chip that owns the
- * slot. The chip comes from the slot rather than the payload so the instrument stays
- * visible in the list it was loaded into.
+ * Builds the instrument a preset replaces a slot with, tagged for the chip that owns the slot
+ * so it stays in the list it was loaded into.
  */
 export function instrumentFromPreset(
 	payload: InstrumentPresetPayload,
@@ -39,7 +38,25 @@ export function instrumentFromPreset(
 		id,
 		payload.rows.map((row) => new InstrumentRow(row)),
 		payload.loop,
-		payload.name || `Instrument ${id}`,
+		payload.name,
 		chipType
 	);
+}
+
+/**
+ * Places a preset in the instrument slot carrying the given id, tagged for the chip that owns
+ * the slot. Returns the updated instrument list, or null when the project holds no such slot.
+ */
+export function applyInstrumentPreset(
+	instruments: Instrument[],
+	payload: InstrumentPresetPayload,
+	id: string,
+	chipType: string
+): Instrument[] | null {
+	const index = instruments.findIndex((instrument) => instrument.id === id);
+	if (index < 0) return null;
+
+	const updated = [...instruments];
+	updated[index] = instrumentFromPreset(payload, id, chipType);
+	return updated;
 }

--- a/src/lib/services/instrument/instrument-preset.ts
+++ b/src/lib/services/instrument/instrument-preset.ts
@@ -1,0 +1,45 @@
+import { Instrument, InstrumentRow } from '../../models/song';
+
+export type InstrumentPresetPayload = {
+	rows: Record<string, unknown>[];
+	loop: number;
+	name: string;
+};
+
+/**
+ * Reads an instrument preset payload, accepting either a bare instrument object or a
+ * single-element array of one, which is the shape both the bundled presets and exported
+ * instrument files come in. Returns null when the payload carries no row array.
+ */
+export function parseInstrumentPreset(parsed: unknown): InstrumentPresetPayload | null {
+	const item = Array.isArray(parsed) ? parsed[0] : parsed;
+	if (item == null || typeof item !== 'object') return null;
+
+	const record = item as Record<string, unknown>;
+	if (!Array.isArray(record.rows)) return null;
+
+	return {
+		rows: record.rows as Record<string, unknown>[],
+		loop: typeof record.loop === 'number' ? record.loop : 0,
+		name: record.name != null ? String(record.name) : ''
+	};
+}
+
+/**
+ * Builds the instrument a preset replaces a slot with, tagged for the chip that owns the
+ * slot. The chip comes from the slot rather than the payload so the instrument stays
+ * visible in the list it was loaded into.
+ */
+export function instrumentFromPreset(
+	payload: InstrumentPresetPayload,
+	id: string,
+	chipType: string
+): Instrument {
+	return new Instrument(
+		id,
+		payload.rows.map((row) => new InstrumentRow(row)),
+		payload.loop,
+		payload.name || `Instrument ${id}`,
+		chipType
+	);
+}

--- a/tests/lib/services/instrument/instrument-preset.test.ts
+++ b/tests/lib/services/instrument/instrument-preset.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { resolveInstrumentChipType } from '@/lib/services/instrument/instrument-filter';
+import { Instrument } from '@/lib/models/song';
+import { filterInstrumentsForChip } from '@/lib/services/instrument/instrument-filter';
 import {
+	applyInstrumentPreset,
 	instrumentFromPreset,
 	parseInstrumentPreset
 } from '@/lib/services/instrument/instrument-preset';
 
-const PRESET = {
+const AY_PRESET = {
 	chipType: 'ay',
 	name: 'Glass Break',
 	loop: 1,
@@ -15,17 +17,32 @@ const PRESET = {
 	]
 };
 
+const NES_PRESET = {
+	chipType: 'nes',
+	name: 'Square Lead',
+	loop: 0,
+	rows: [{ pulseWidth: 2, volumeOrRate: 15 }]
+};
+
+function projectInstruments(): Instrument[] {
+	return [
+		new Instrument('01', [], 0, 'Lead', 'ay'),
+		new Instrument('03', [], 0, 'Empty NES slot', 'nes')
+	];
+}
+
 describe('parseInstrumentPreset', () => {
 	it('reads a bare instrument object', () => {
-		expect(parseInstrumentPreset(PRESET)).toEqual({
+		expect(parseInstrumentPreset(AY_PRESET)).toEqual({
 			name: 'Glass Break',
 			loop: 1,
-			rows: PRESET.rows
+			rows: AY_PRESET.rows
 		});
 	});
 
-	it('reads the first entry of a single-element array', () => {
-		expect(parseInstrumentPreset([PRESET])?.name).toBe('Glass Break');
+	it('reads the first entry when the JSON holds an array', () => {
+		const second = { ...AY_PRESET, name: 'Kick' };
+		expect(parseInstrumentPreset([AY_PRESET, second])?.name).toBe('Glass Break');
 	});
 
 	it('defaults a missing loop and name', () => {
@@ -43,28 +60,28 @@ describe('parseInstrumentPreset', () => {
 
 describe('instrumentFromPreset', () => {
 	it('tags the instrument with the chip that owns the slot', () => {
-		const payload = parseInstrumentPreset(PRESET)!;
-		const instrument = instrumentFromPreset(payload, '03', 'nes');
+		const ayInstrument = instrumentFromPreset(parseInstrumentPreset(AY_PRESET)!, '01', 'ay');
+		const nesInstrument = instrumentFromPreset(parseInstrumentPreset(NES_PRESET)!, '03', 'nes');
 
-		expect(instrument.chipType).toBe('nes');
-		expect(resolveInstrumentChipType(instrument)).toBe('nes');
+		expect(ayInstrument.chipType).toBe('ay');
+		expect(nesInstrument.chipType).toBe('nes');
 	});
 
-	it('keeps the loaded instrument visible in the list it was loaded into', () => {
-		const payload = parseInstrumentPreset(PRESET)!;
-		const instrument = instrumentFromPreset(payload, '03', 'nes');
+	it('tags a preset built for another chip for the slot receiving it, rows as they stand', () => {
+		const instrument = instrumentFromPreset(parseInstrumentPreset(AY_PRESET)!, '03', 'nes');
 
-		expect(resolveInstrumentChipType(instrument)).not.toBe(PRESET.chipType);
+		expect(instrument.chipType).toBe('nes');
+		expect(instrument.rows.map((row) => ({ ...row }))).toEqual(AY_PRESET.rows);
 	});
 
 	it('carries the id, rows, loop and name over', () => {
-		const payload = parseInstrumentPreset(PRESET)!;
-		const instrument = instrumentFromPreset(payload, '03', 'ay');
+		const payload = parseInstrumentPreset(AY_PRESET)!;
+		const instrument = instrumentFromPreset(payload, '01', 'ay');
 
-		expect(instrument.id).toBe('03');
+		expect(instrument.id).toBe('01');
 		expect(instrument.loop).toBe(1);
 		expect(instrument.name).toBe('Glass Break');
-		expect(instrument.rows.map((row) => ({ ...row }))).toEqual(PRESET.rows);
+		expect(instrument.rows.map((row) => ({ ...row }))).toEqual(AY_PRESET.rows);
 	});
 
 	it('names the instrument after its slot when the preset has no name', () => {
@@ -73,11 +90,53 @@ describe('instrumentFromPreset', () => {
 	});
 
 	it('copies rows so editing the instrument leaves the payload alone', () => {
-		const payload = parseInstrumentPreset(PRESET)!;
-		const instrument = instrumentFromPreset(payload, '03', 'ay');
+		const payload = parseInstrumentPreset(AY_PRESET)!;
+		const instrument = instrumentFromPreset(payload, '01', 'ay');
 
-		(instrument.rows[0] as Record<string, unknown>).volume = 0;
+		instrument.rows[0].volume = 0;
 
-		expect(PRESET.rows[0].volume).toBe(15);
+		expect(AY_PRESET.rows[0].volume).toBe(15);
+	});
+});
+
+describe('applyInstrumentPreset', () => {
+	it('keeps the loaded instrument in the list of the chip that owns the slot', () => {
+		const intoAySlot = applyInstrumentPreset(
+			projectInstruments(),
+			parseInstrumentPreset(AY_PRESET)!,
+			'01',
+			'ay'
+		)!;
+		const intoNesSlot = applyInstrumentPreset(
+			projectInstruments(),
+			parseInstrumentPreset(NES_PRESET)!,
+			'03',
+			'nes'
+		)!;
+
+		expect(filterInstrumentsForChip(intoAySlot, 'ay').map((inst) => inst.id)).toEqual(['01']);
+		expect(filterInstrumentsForChip(intoNesSlot, 'nes').map((inst) => inst.id)).toEqual(['03']);
+	});
+
+	it('replaces the addressed slot and holds on to the rest', () => {
+		const instruments = projectInstruments();
+		const payload = parseInstrumentPreset(NES_PRESET)!;
+		const updated = applyInstrumentPreset(instruments, payload, '03', 'nes')!;
+
+		expect(updated).toHaveLength(2);
+		expect(updated[0]).toBe(instruments[0]);
+		expect(updated[1].name).toBe('Square Lead');
+	});
+
+	it('leaves the list it was given untouched', () => {
+		const instruments = projectInstruments();
+		applyInstrumentPreset(instruments, parseInstrumentPreset(NES_PRESET)!, '03', 'nes');
+
+		expect(instruments[1].name).toBe('Empty NES slot');
+	});
+
+	it('reports no slot when the project holds no instrument with that id', () => {
+		const payload = parseInstrumentPreset(AY_PRESET)!;
+		expect(applyInstrumentPreset(projectInstruments(), payload, '99', 'ay')).toBeNull();
 	});
 });

--- a/tests/lib/services/instrument/instrument-preset.test.ts
+++ b/tests/lib/services/instrument/instrument-preset.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { resolveInstrumentChipType } from '@/lib/services/instrument/instrument-filter';
+import {
+	instrumentFromPreset,
+	parseInstrumentPreset
+} from '@/lib/services/instrument/instrument-preset';
+
+const PRESET = {
+	chipType: 'ay',
+	name: 'Glass Break',
+	loop: 1,
+	rows: [
+		{ tone: true, volume: 15 },
+		{ tone: false, volume: 7 }
+	]
+};
+
+describe('parseInstrumentPreset', () => {
+	it('reads a bare instrument object', () => {
+		expect(parseInstrumentPreset(PRESET)).toEqual({
+			name: 'Glass Break',
+			loop: 1,
+			rows: PRESET.rows
+		});
+	});
+
+	it('reads the first entry of a single-element array', () => {
+		expect(parseInstrumentPreset([PRESET])?.name).toBe('Glass Break');
+	});
+
+	it('defaults a missing loop and name', () => {
+		const payload = parseInstrumentPreset({ rows: [] });
+		expect(payload).toEqual({ rows: [], loop: 0, name: '' });
+	});
+
+	it('rejects payloads carrying no row array', () => {
+		expect(parseInstrumentPreset(null)).toBeNull();
+		expect(parseInstrumentPreset('instrument')).toBeNull();
+		expect(parseInstrumentPreset({ name: 'No rows' })).toBeNull();
+		expect(parseInstrumentPreset({ rows: 'nope' })).toBeNull();
+	});
+});
+
+describe('instrumentFromPreset', () => {
+	it('tags the instrument with the chip that owns the slot', () => {
+		const payload = parseInstrumentPreset(PRESET)!;
+		const instrument = instrumentFromPreset(payload, '03', 'nes');
+
+		expect(instrument.chipType).toBe('nes');
+		expect(resolveInstrumentChipType(instrument)).toBe('nes');
+	});
+
+	it('keeps the loaded instrument visible in the list it was loaded into', () => {
+		const payload = parseInstrumentPreset(PRESET)!;
+		const instrument = instrumentFromPreset(payload, '03', 'nes');
+
+		expect(resolveInstrumentChipType(instrument)).not.toBe(PRESET.chipType);
+	});
+
+	it('carries the id, rows, loop and name over', () => {
+		const payload = parseInstrumentPreset(PRESET)!;
+		const instrument = instrumentFromPreset(payload, '03', 'ay');
+
+		expect(instrument.id).toBe('03');
+		expect(instrument.loop).toBe(1);
+		expect(instrument.name).toBe('Glass Break');
+		expect(instrument.rows.map((row) => ({ ...row }))).toEqual(PRESET.rows);
+	});
+
+	it('names the instrument after its slot when the preset has no name', () => {
+		const payload = parseInstrumentPreset({ rows: [] })!;
+		expect(instrumentFromPreset(payload, '07', 'ay').name).toBe('Instrument 07');
+	});
+
+	it('copies rows so editing the instrument leaves the payload alone', () => {
+		const payload = parseInstrumentPreset(PRESET)!;
+		const instrument = instrumentFromPreset(payload, '03', 'ay');
+
+		(instrument.rows[0] as Record<string, unknown>).volume = 0;
+
+		expect(PRESET.rows[0].volume).toBe(15);
+	});
+});


### PR DESCRIPTION
Loading presets for other chips than `ay` is currently broken.

`Instrument`'s constructor defaults `chipType` to `'ay'` (`src/lib/models/song.ts:58`). Both `loadInstrument` and `openPresets` builds an instrument with `chip.type`, then immediately discard as the `chipType` argument is being silently dropped.

```js
updated[idx] = new InstrumentModel(currentId, rows, replacement.loop, replacement.name);  // chipType → 'ay'
```

The PR fixes that omission.

## Refactor

A small refactor has been made: both `loadInstrument` and `openPresets` rewrite the same functionality, and only one line had `chip.type`.

- New `src/lib/services/instrument/instrument-preset.ts` owning `parseInstrumentPreset`, `instrumentFromPreset` and `applyInstrumentPreset`.
- The function`replaceInstrumentFromPreset` unifies the duplicated logic.
- Two further copies of the unwrap-and-validate logic are gone (`PresetsModal.handleLoad`).
- The `Instrument` constructor owns the `Instrument ${id}` name default instead of it being applied twice.
- Some minor tests added.

Feel free to discard any change you feel unwanted, the actual fix is the first commit.

## Behavior

Two consequences of the deduplication:

- `PresetsModal` resolves the parsed payload rather than the raw object.
- `getNameFromPresetContent` returns `null` for a preset JSON carrying no `rows` array, so its tree label falls back to the filename. This is the only observable behavior change beyond the fix.
